### PR TITLE
Import super namespace so the rtype can refer to it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.3.2 (2018-11-xx)
+
+* Fix another warning in rustc 1.29 or later #12
+
 ## 0.3.1 (2018-10-28)
 
 * Upgrade `syn` crate to 0.15

--- a/src/message.rs
+++ b/src/message.rs
@@ -33,9 +33,10 @@ pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
 
     quote!{
         mod #dummy_const {
+            use super::*;
             extern crate actix;
 
-            impl #impl_generics actix::Message for super::#name #ty_generics #where_clause {
+            impl #impl_generics actix::Message for #name #ty_generics #where_clause {
                 #item_type
             }
         }


### PR DESCRIPTION
db60cfc isn't enough to suppress the warning as the `#item_type` may have
types not included in the prelude. This fixes the following example to be
compiled without warnings.

```
pub struct A;
pub struct B;

#[derive(Message)]
#[rtype(result = "Result<A, B>")]
pub struct Msg;
```